### PR TITLE
Improve calculation of min-value function V

### DIFF
--- a/DiscreteLQR.py
+++ b/DiscreteLQR.py
@@ -2,7 +2,6 @@ import copy
 import numpy as np
 import PrettyPrinter as ppm
 
-
 class DiscreteLQR:
     """
     Record the defining properties and calculate key features
@@ -128,6 +127,12 @@ class DiscreteLQR:
     To get the optimal trajectory for a given initial point,
     use the method "bestxul".
 
+    ## THE VALUE FUNCTION ##
+
+    A system object has a method that returns the minimum cost from any
+    initial state, namely
+        V(x0) - scalar value of V at point x0, where x0 is an n-by-1 2D array.
+
     ## VALUE FUNCTION GRADIENTS ##
 
     Method list: Let V(x0) denote the minimum value in the optimization problem
@@ -178,6 +183,7 @@ class DiscreteLQR:
     for debugging in the future.
 
     Philip D Loewen,
+    ... 2024-07-16: Get V(x0) from the initial setup, no trajectory needed!
     ... 2024-07-04: Improve sensitivity functions for the autonomous case
     ... 2024-07-03: Finish some sensitivity functions and testing
     ... 2024-06-30: Check details for the non-apology above
@@ -615,6 +621,15 @@ class DiscreteLQR:
     #########################################################################################################
     ## OPTIMIZATION -- FORWARD/BACKWARD ITERATIONS DEFINE AN OPTIMAL TRAJECTORY AND ITS ASSOCIATED VALUE
     #########################################################################################################
+    def V(self,x0):
+        """
+        Return the minimum cost of a trajectory starting from the point x0.
+        """
+        # print(f"V_mats.shape = {self.V_mats.shape}; v_vecs.shape = {self.v_vecs.shape}.")
+        mincost = 0.5 * x0.T @ self.V_mats[:,:,0] @ x0 + self.v_vecs[:,[0],0].T @ x0 + self.beta[0]
+        # print(f"mincost = {mincost}")
+        return( mincost[0,0] )
+
     def bestxul(self, x0):
         """
         Find optimal state and control sequences and multipliers,
@@ -662,13 +677,6 @@ class DiscreteLQR:
                 + self.c(t)[0:n, [0]]
             )
         return x, u, lam
-
-    def V(self, x0):
-        """
-        Return the minimum cost associated with the given initial point.
-        """
-        bestx, bestu, bestlam = self.bestxul(x0)
-        return self.J(bestx, bestu)
 
     #########################################################################################################
     ## OPTIMIZATION -- LAGRANGE MULTIPLIER APPROACH

--- a/test-LTI-Vonly.py
+++ b/test-LTI-Vonly.py
@@ -1,0 +1,110 @@
+# test-LTI-Vonly.py
+#
+# Exercise the optimization part of the LQR module, with an LTI system.
+#   * Print the KKT matrix to make sure it matches the theory.
+#   * Compare the optimal trajectories from the KKT method
+#     with the trajectories from the forward-backward method.
+#
+# Simple stripped-down version of the original in test-LQR-optim.py
+#
+# (c) Philip D Loewen, 2024-07-16
+
+import numpy as np
+
+# Local modules
+import DiscreteLQR as LQRmodule
+import PrettyPrinter as ppm  # PDL 2024-06-03
+
+#######################################################################
+# Choose basic system parameters.
+# Recommended values for each of m,n,T are in the interval [1,9].
+#######################################################################
+n = 5  # State vector dimension
+m = 3  # Input/control vector dimension
+T = 8  # Literal final time. Interesting subscripts are 0,...,T
+
+x0 = np.random.rand(n, 1)  # Initial state
+
+#######################################################################
+# Invent system ingredients whose digit patterns will be recognizable
+# in the KKT mtx.
+#######################################################################
+# Dynamics
+for t in [0]:
+    # Matrix A[t], entry ij, will have value whose digits look like 0.tij,
+    # provide all of t,i,j are in the interval [0,9]. Note that "entry ij"
+    # uses 1-based indexing like in math writing, not Pythonic indexes.
+    # For matrix B[t], the form is the same but the numbers are negative.
+
+    n_ones = np.ones((n, 1))
+    Arow = np.array(range(1, n + 1)).reshape((1, n))
+    A = t * np.ones((n, n)) / 10.0 + n_ones @ Arow / 1000.0 + Arow.T @ n_ones.T / 100.0
+    # ppm.ppm(A,f"A[{t}]",sigfigs=3)
+
+    m_ones = np.ones((m, 1))
+    Brow = np.array(range(1, m + 1)).reshape((1, m))
+    B = -(
+        t * np.ones((n, m)) / 10.0 + n_ones @ Brow / 1000.0 + Arow.T @ m_ones.T / 100.0
+    )
+    # ppm.ppm(B,f"B[{t}]",sigfigs=3)
+
+    F = np.hstack((A, B))
+    f = (0.001 + np.ones((n, 1)) * t * 1.11).reshape((n, 1))
+
+# Costs -- complicated by requirements of symmetry and positivity
+for t in [0]:
+    # Similar story to the setup for matrix A, but with a bigger diagonal.
+    C0 = t * np.ones((n + m, n + m))
+    C0 += 10 * np.eye(n + m)
+    C0 += (
+        np.ones((m + n, 1)) @ np.array(range(1, m + n + 1)).reshape((1, m + n)) / 200.0
+    )
+    C0 += np.array(range(1, m + n + 1)).reshape((m + n, 1)) @ np.ones((1, m + n)) / 20.0
+    C0 = (C0 + C0.T) / 2.0
+
+    C = C0
+    c = -(0.001 + np.ones((n + m, 1)) * t * 1.01).reshape((m + n, 1))
+
+#######################################################################
+# Instantiate the system and have it print what it internalizes.
+#######################################################################
+myLQRsystem = LQRmodule.DiscreteLQR(C, c, F, f, T=T)
+
+# myLQRsystem.printself()
+
+###############################################################
+Ntests = 20
+tolerance = 1E-9
+worsttest = 0
+worstrelerr = -1.0
+worstx0 = np.random.rand(n,1)
+
+for test in range(1,Ntests+1):
+    print(f"\n-- Test number {test} --")
+    x0 = np.random.rand(n,1) * 10 - 5.0
+    ppm.ppm(x0.T,"transpose of the initial point x0")
+    Vquad = myLQRsystem.V(x0)
+
+    bestx, bestu, bestlam  = myLQRsystem.bestxul(x0)
+    Valt = myLQRsystem.J(bestx,bestu)
+
+    relerr = np.abs((Vquad - Valt) / Vquad )
+
+    print(f"Quadratic prediction of V(x0):   {Vquad:13.6E}")
+    print(f"Trajectory-based calc for V(x0): {Valt:13.6E}")
+    print(f"Relative discrepancy in these:   {relerr:8.1E}")
+
+    if relerr > worstrelerr:
+        worsttest = test
+        worstrelerr = relerr
+        worstx0 = x0
+
+print(f"\nTest {worsttest} was the worst of these {Ntests}.")
+ppm.ppm(worstx0.T,f"transpose of the initial point x0 for test {worsttest}")
+print(f"Test {worsttest} had a relative error {worstrelerr:7.1E}.")
+
+if worstrelerr < tolerance:
+    print("All the other tests were at least as good. This outcome is acceptable.\n")
+else:
+    print("Further investigation is required.\n")
+


### PR DESCRIPTION
Previously the number V(x0) was calculated by finding the best trajectory from that initial state, and evalating its J-value. But the whole point of the backward iteration used to set up the system is to determine a simple quadratic formula that returns the coefficients defining V() directly. So let's use that formula when someone asks for a V-value. This change comes with a test script that works quite well.